### PR TITLE
Fixes #9 : LoadCombination debug

### DIFF
--- a/src/compas_fea2/problem/combinations.py
+++ b/src/compas_fea2/problem/combinations.py
@@ -1,5 +1,5 @@
 from compas_fea2.base import FEAData
-
+import compas_fea2
 
 class LoadCombination(FEAData):
     """Load combination used to combine load fields together at each step.
@@ -56,7 +56,7 @@ class LoadCombination(FEAData):
     # BUG: Rewrite. this is not general and does not account for different loads types
     @property
     def node_load(self):
-        """Generator returning each node and the correponding total factored
+        """Generator returning each node and the corresponding total factored
         load of the combination.
 
         Returns
@@ -66,10 +66,12 @@ class LoadCombination(FEAData):
         """
         nodes_loads = {}
         for load_field in self.step.load_fields:
-            if load_field.load_case in self.factors:
-                for node, load in load_field.node_load:
-                    if node in nodes_loads:
-                        nodes_loads[node] += load * self.factors[load_field.load_case]
-                    else:
-                        nodes_loads[node] = load * self.factors[load_field.load_case]
+            if isinstance(load_field, compas_fea2.problem.LoadField):
+                if load_field.load_case in self.factors:
+                    for node in load_field.distribution :
+                        for load in load_field.loads:
+                            if node in nodes_loads:
+                                nodes_loads[node] += load * self.factors[load_field.load_case]
+                            else:
+                                nodes_loads[node] = load * self.factors[load_field.load_case]
         return zip(list(nodes_loads.keys()), list(nodes_loads.values()))


### PR DESCRIPTION
The node_load method of LoadCombination is adapted so as it only goes through the NodeLoadFields and return the factored loading of mechanically loaded nodes (node loaded by imposed displacements and temperature are excluded, which make sense since there are not supposed to be factored)
The displacement/temperature loads can be found in the step attributes.

### What type of change is this?

- [ X ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
