### PR TITLE
add_connector debug

### DIFF
--- a/src/compas_fea2/model/model.py
+++ b/src/compas_fea2/model/model.py
@@ -1380,7 +1380,8 @@ class Model(FEAData):
             raise TypeError("{!r} is not a Connector.".format(connector))
         self._connectors.add(connector)
         connector._registration = self
-        self.add_group(connector.nodes)
+        if isinstance(connector.nodes, _Group):
+            self.add_group(connector.nodes)
         return connector
 
     def add_connectors(self, connectors):


### PR DESCRIPTION
The nodes attributes in compas_fea2 objects can be implemented as Nodegroup (set) or list of nodes. This debugging takes into account the potential presence of list of nodes.